### PR TITLE
Clean up bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # learn-vue
 
+## Prerequisites
+1. install Docker
+1. install Docker Compose
+1. install Git
+1. clone repository: `git clone --recursive https://github.com/thierved/learn-vue.git`
+
 ## Getting Started
+1. configure project: `./bootstrap.sh`
 1. start service: `docker compose up`
 1. browse to development server at http://localhost:8080
 

--- a/scripts/bootstrap/functions.sh
+++ b/scripts/bootstrap/functions.sh
@@ -35,7 +35,6 @@ setup_containers() (
   case $environment in
     'development')
       docker compose build --pull
-      docker compose run backend scripts/setup_app.sh
     ;;
   esac
 )


### PR DESCRIPTION
Remove unnecessary setup step required for backend container service to avoid error message when running `bootstrap.sh`.

Should close issue #2 