### PR TITLE
Store cache within artifacts/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-node_modules
+artifacts/*
+node_modules/
 /dist
 
 
@@ -21,3 +22,5 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+!.keep

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,19 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
-  transpileDependencies: true
+  transpileDependencies: true,
+  chainWebpack: config => {
+    config.module
+      .rule('js')
+      .use('babel-loader')
+        .tap(options => {
+          options['cacheDirectory'] = "artifacts/.cache/babel-loader/"
+          return options
+        })
+    config
+      .plugin('eslint')
+      .tap(args => {
+        args[0].cacheLocation = '/usr/src/app/artifacts/.cache/eslint/5fc34bca.json'
+        return args
+      })
+  }
 })


### PR DESCRIPTION
This allows the fix for https://github.com/thierved/learn-vue/issues/6 to not break the set up for developers on Linux machines.

This avoids permission issues when cache is stored in `node_modules/.cache/` folder.